### PR TITLE
minor defaulting of an empty value to 0

### DIFF
--- a/Lib/GoogleChart.php
+++ b/Lib/GoogleChart.php
@@ -153,7 +153,7 @@ class GoogleChart extends Object
             $i = 0;
             foreach ($this->columns as $key => $column)
             {
-                $row[$i] = $data[$key];
+                $row[$i] = (!empty($data[$key]) ? $data[$key] : 0);
                 $i++;
             }
             $this->rows[] = $row;


### PR DESCRIPTION
If you dataset isn't complete (keys w/o values) it errors/fails without some default value...
this is a simple first pass
