### PR TITLE
Add support for data table roles

### DIFF
--- a/View/Helper/GoogleChartsHelper.php
+++ b/View/Helper/GoogleChartsHelper.php
@@ -158,6 +158,15 @@ class GoogleChartsHelper extends AppHelper
 
         $scriptOutput .= "]);";
 
+        $columns = array_values($chart->columns);
+        foreach ($columns as $numeric_key => $column)
+        {
+        	if (isset($column['role']))
+        	{
+        		$scriptOutput .= "\nchartData.setColumnProperty($numeric_key, 'role', '{$column['role']}');";
+        	}
+        }
+        
         $chartVarId = !empty($variableId) ? "chart_{$variableId}" : uniqid ("chart_");
 
         $scriptOutput .= "{$chartVarId} = chart = new google.visualization.{$chart->type}(document.getElementById('{$chart->div}'));";


### PR DESCRIPTION
Currently, the Google Charts plugin doesn't recognize roles (like 'annotation') for specified columns. This will allow the use of roles like in the following example: 

```
$chart->columns(array(
    'category' => array(
        'type' => 'string',
        'label' => 'Category'
    ),
    'score' => array(
        'type' => 'number',
        'label' => 'Score'
    ),
    'annotation' => array(
        'type' => 'string', 
        'role' => 'annotation',
        'label' => 'Annotation'
    )
);
$chart->addRow(array(
    'category' => 'BAC After Birthday Party',
    'score' => .240,
    'annotation' => 'Hammered'
));
```
